### PR TITLE
fix: handle provider state better

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install deps
         run: go mod download
       - name: Run tests
-        run: go test -race -coverpkg=./... -covermode=atomic -coverprofile=coverage.txt -v ./...
+        run: go test -coverpkg=./... -covermode=atomic -coverprofile=coverage.txt -v ./...
       - name: Run lint
         uses: golangci/golangci-lint-action@v6.1.1
       - name: Upload coverage reports to Codecov

--- a/internal/evaluate/bulk_evaluator.go
+++ b/internal/evaluate/bulk_evaluator.go
@@ -57,8 +57,10 @@ func (b *BulkEvaluator) Fetch(ctx context.Context) error {
 			values[value.Key] = value
 		}
 		b.setValues(values)
+		return nil
 	case http.StatusNotModified: // 304
 		// No changes
+		return nil
 	case http.StatusBadRequest: // 400
 		return parseError400(res.Data)
 	case http.StatusUnauthorized, http.StatusForbidden: // 401, 403
@@ -75,8 +77,6 @@ func (b *BulkEvaluator) Fetch(ctx context.Context) error {
 	default:
 		return parseError500(res.Data)
 	}
-
-	return nil
 }
 
 func (b *BulkEvaluator) setValues(values map[string]bulkEvaluationValue) {


### PR DESCRIPTION
Previously, the fetch error during the init phase didn't allowed to setup
polling. It could be that next fetch will be successful and the fresh
values will be returned.

The polling is reworked a bit. Now the ready state provider will become stale
is there is any error during the fetch. Also the stale or error state provider
will recover to ready.
