### PR TITLE
feat: add WithFromEnv, modernize, add evaluation tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ go.work.sum
 
 # env file
 .env
+
+# Coverage output
+coverage.txt

--- a/.mise.toml
+++ b/.mise.toml
@@ -5,3 +5,7 @@ golangci-lint = "2.12.2"
 [tasks.lint]
 description = "Run golangci-lint"
 run = "golangci-lint run"
+
+[tasks.test]
+description = "Run tests with race detection and coverage"
+run = "go test -race -coverpkg=./... -covermode=atomic -coverprofile=coverage.txt -v ./..."

--- a/README.md
+++ b/README.md
@@ -11,19 +11,51 @@ Add a line to your `go.mod` file
 replace github.com/open-feature/go-sdk-contrib/providers/ofrep => github.com/erka/openfeature-go-ofrep-provider v0.0.1
 ```
 
-For OFREP Bulk provider example
+## Configuration
+
+You can configure the provider using following configuration options,
+
+| Configuration option | Details                                                                                                                 |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| WithApiKeyAuth       | Set the token to be used with "X-API-Key" header                                                                        |
+| WithBearerToken      | Set the token to be used with "Bearer" HTTP Authorization schema                                                        |
+| WithClient           | Provide a custom, pre-configured http.Client for OFREP service communication                                            |
+| WithHeaderProvider   | Register a custom header provider for OFREP calls. You may utilize this for custom authentication/authorization headers |
+| WithHeader           | Set a custom header to be used for authorization                                                                        |
+| WithBaseURI          | Set the base URI of the OFREP service                                                                                   |
+| WithTimeout          | Set the timeout for the http client used for communication with the OFREP service (ignored if custom client is used)    |
+| WithFromEnv          | Configure the provider using environment variables                                                                      |
+
+For example, consider below example which sets bearer token and provides a customized http client,
 
 ```go
 import(
 	"github.com/open-feature/go-sdk-contrib/providers/ofrep"
 	of "github.com/open-feature/go-sdk/openfeature"
 )
-///.....
-of.SetEvaluationContext(of.NewEvaluationContext(...))
-p := ofrep.NewBulkProvider(baseUrl, ....)
-err := of.SetProviderAndWait(p)
-if err != nil {
-  // handle the error
-}
-client := of.NewClient("app")
+
+provider := ofrep.NewProvider(
+    "http://localhost:8016",
+    ofrep.WithBearerToken("TOKEN"),
+    ofrep.WithClient(&http.Client{
+        Timeout: 1 * time.Second,
+    }))
 ```
+
+### Environment Variable Configuration (Experimental)
+
+You can use the `WithFromEnv()` option to configure the provider using environment variables:
+
+```go
+provider := ofrep.NewProvider(
+    "http://localhost:8016",
+    ofrep.WithFromEnv())
+```
+
+Supported environment variables:
+
+| Environment Variable | Description                                                                           | Example                   |
+| -------------------- | ------------------------------------------------------------------------------------- | ------------------------- |
+| OFREP_ENDPOINT       | Base URI for the OFREP service (overrides the baseUri parameter)                      | `http://localhost:8016`   |
+| OFREP_TIMEOUT_MS     | Timeout duration in milliseconds for HTTP requests (ignored if custom client is used) | `5000`                    |
+| OFREP_HEADERS        | Comma-separated custom headers                                                        | `Key1=Value1,Key2=Value2` |

--- a/evaluate.go
+++ b/evaluate.go
@@ -9,13 +9,13 @@ import (
 // Evaluator contract for flag evaluation.
 type Evaluator interface {
 	ResolveBoolean(ctx context.Context, key string, defaultValue bool,
-		evalCtx map[string]interface{}) of.BoolResolutionDetail
+		evalCtx map[string]any) of.BoolResolutionDetail
 	ResolveString(ctx context.Context, key string, defaultValue string,
-		evalCtx map[string]interface{}) of.StringResolutionDetail
+		evalCtx map[string]any) of.StringResolutionDetail
 	ResolveFloat(ctx context.Context, key string, defaultValue float64,
-		evalCtx map[string]interface{}) of.FloatResolutionDetail
+		evalCtx map[string]any) of.FloatResolutionDetail
 	ResolveInt(ctx context.Context, key string, defaultValue int64,
-		evalCtx map[string]interface{}) of.IntResolutionDetail
-	ResolveObject(ctx context.Context, key string, defaultValue interface{},
-		evalCtx map[string]interface{}) of.InterfaceResolutionDetail
+		evalCtx map[string]any) of.IntResolutionDetail
+	ResolveObject(ctx context.Context, key string, defaultValue any,
+		evalCtx map[string]any) of.InterfaceResolutionDetail
 }

--- a/internal/evaluate/flags.go
+++ b/internal/evaluate/flags.go
@@ -14,7 +14,7 @@ type Flags struct {
 }
 
 type resolver interface {
-	resolveSingle(ctx context.Context, key string, evalCtx map[string]interface{}) (*successDto, *of.ResolutionError)
+	resolveSingle(ctx context.Context, key string, evalCtx map[string]any) (*successDto, *of.ResolutionError)
 }
 
 func NewFlagsEvaluator(cfg outbound.Configuration) *Flags {
@@ -23,7 +23,7 @@ func NewFlagsEvaluator(cfg outbound.Configuration) *Flags {
 	}
 }
 
-func (h Flags) ResolveBoolean(ctx context.Context, key string, defaultValue bool, evalCtx map[string]interface{}) of.BoolResolutionDetail {
+func (h Flags) ResolveBoolean(ctx context.Context, key string, defaultValue bool, evalCtx map[string]any) of.BoolResolutionDetail {
 	value, resolution := resolve(ctx, h.resolver, key, defaultValue, evalCtx, convertDefault)
 	return of.BoolResolutionDetail{
 		Value:                    value,
@@ -31,7 +31,7 @@ func (h Flags) ResolveBoolean(ctx context.Context, key string, defaultValue bool
 	}
 }
 
-func (h Flags) ResolveString(ctx context.Context, key string, defaultValue string, evalCtx map[string]interface{}) of.StringResolutionDetail {
+func (h Flags) ResolveString(ctx context.Context, key string, defaultValue string, evalCtx map[string]any) of.StringResolutionDetail {
 	value, resolution := resolve(ctx, h.resolver, key, defaultValue, evalCtx, convertDefault)
 
 	return of.StringResolutionDetail{
@@ -40,7 +40,7 @@ func (h Flags) ResolveString(ctx context.Context, key string, defaultValue strin
 	}
 }
 
-func (h Flags) ResolveFloat(ctx context.Context, key string, defaultValue float64, evalCtx map[string]interface{}) of.FloatResolutionDetail {
+func (h Flags) ResolveFloat(ctx context.Context, key string, defaultValue float64, evalCtx map[string]any) of.FloatResolutionDetail {
 	value, resolution := resolve(ctx, h.resolver, key, defaultValue, evalCtx, convertToFloat64)
 	return of.FloatResolutionDetail{
 		Value:                    value,
@@ -48,7 +48,7 @@ func (h Flags) ResolveFloat(ctx context.Context, key string, defaultValue float6
 	}
 }
 
-func (h Flags) ResolveInt(ctx context.Context, key string, defaultValue int64, evalCtx map[string]interface{}) of.IntResolutionDetail {
+func (h Flags) ResolveInt(ctx context.Context, key string, defaultValue int64, evalCtx map[string]any) of.IntResolutionDetail {
 	value, resolution := resolve(ctx, h.resolver, key, defaultValue, evalCtx, convertToInt64)
 	return of.IntResolutionDetail{
 		Value:                    value,
@@ -56,7 +56,7 @@ func (h Flags) ResolveInt(ctx context.Context, key string, defaultValue int64, e
 	}
 }
 
-func (h Flags) ResolveObject(ctx context.Context, key string, defaultValue interface{}, evalCtx map[string]interface{}) of.InterfaceResolutionDetail {
+func (h Flags) ResolveObject(ctx context.Context, key string, defaultValue any, evalCtx map[string]any) of.InterfaceResolutionDetail {
 	value, resolution := resolve(ctx, h.resolver, key, defaultValue, evalCtx, convertDefault)
 	return of.InterfaceResolutionDetail{
 		Value:                    value,
@@ -66,7 +66,7 @@ func (h Flags) ResolveObject(ctx context.Context, key string, defaultValue inter
 
 type convertFunc[T any] func(v any) (T, bool)
 
-func resolve[T any](ctx context.Context, resolver resolver, key string, defaultValue T, evalCtx map[string]interface{}, convert convertFunc[T]) (T, of.ProviderResolutionDetail) {
+func resolve[T any](ctx context.Context, resolver resolver, key string, defaultValue T, evalCtx map[string]any, convert convertFunc[T]) (T, of.ProviderResolutionDetail) {
 	evalSuccess, resolutionError := resolver.resolveSingle(ctx, key, evalCtx)
 	if resolutionError != nil {
 		return defaultValue, of.ProviderResolutionDetail{

--- a/internal/evaluate/flags_test.go
+++ b/internal/evaluate/flags_test.go
@@ -13,12 +13,12 @@ type mockResolver struct {
 	err     *of.ResolutionError
 }
 
-func (m mockResolver) resolveSingle(ctx context.Context, key string, evalCtx map[string]interface{}) (*successDto, *of.ResolutionError) {
+func (m mockResolver) resolveSingle(ctx context.Context, key string, evalCtx map[string]any) (*successDto, *of.ResolutionError) {
 	return m.success, m.err
 }
 
 type knownTypes interface {
-	int64 | bool | float64 | string | interface{}
+	int64 | bool | float64 | string | any
 }
 
 type testDefinition[T knownTypes] struct {
@@ -322,13 +322,13 @@ func TestStringEvaluation(t *testing.T) {
 func TestObjectEvaluation(t *testing.T) {
 	ctx := context.Background()
 
-	tests := []testDefinition[interface{}]{
+	tests := []testDefinition[any]{
 		{
 			name: "Success evaluation",
 			resolver: mockResolver{
 				success: &successObject,
 			},
-			defaultValue: map[string]interface{}{},
+			defaultValue: map[string]any{},
 			expect:       successObject.Value,
 		},
 		{
@@ -337,16 +337,16 @@ func TestObjectEvaluation(t *testing.T) {
 				err: &parseError,
 			},
 			isError:      true,
-			defaultValue: map[string]interface{}{},
-			expect:       map[string]interface{}{},
+			defaultValue: map[string]any{},
+			expect:       map[string]any{},
 		},
 		{
 			name: "disabled flag",
 			resolver: mockResolver{
 				success: &successDisabled,
 			},
-			defaultValue: map[string]interface{}{},
-			expect:       map[string]interface{}{},
+			defaultValue: map[string]any{},
+			expect:       map[string]any{},
 			isError:      false,
 		},
 	}

--- a/internal/evaluate/resolver.go
+++ b/internal/evaluate/resolver.go
@@ -28,7 +28,7 @@ func NewOutboundResolver(cfg outbound.Configuration) *OutboundResolver {
 	return &OutboundResolver{client: outbound.NewHTTP(cfg)}
 }
 
-func (g *OutboundResolver) resolveSingle(ctx context.Context, key string, evalCtx map[string]interface{}) (
+func (g *OutboundResolver) resolveSingle(ctx context.Context, key string, evalCtx map[string]any) (
 	*successDto, *of.ResolutionError,
 ) {
 	b, err := json.Marshal(requestFrom(evalCtx))
@@ -143,10 +143,10 @@ func parseError500(data []byte) *of.ResolutionError {
 // DTOs and OFREP models
 
 type successDto struct {
-	Value    interface{}
+	Value    any
 	Reason   string
 	Variant  string
-	Metadata map[string]interface{}
+	Metadata map[string]any
 }
 
 func toSuccessDto(e evaluationSuccess) (*successDto, *of.ResolutionError) {
@@ -157,7 +157,7 @@ func toSuccessDto(e evaluationSuccess) (*successDto, *of.ResolutionError) {
 	}
 
 	if e.Metadata != nil {
-		m, ok := e.Metadata.(map[string]interface{})
+		m, ok := e.Metadata.(map[string]any)
 		if !ok {
 			resErr := of.NewParseErrorResolutionError("metadata must be a map of string keys and arbitrary values")
 			return nil, &resErr
@@ -168,21 +168,21 @@ func toSuccessDto(e evaluationSuccess) (*successDto, *of.ResolutionError) {
 }
 
 type request struct {
-	Context interface{} `json:"context"`
+	Context any `json:"context"`
 }
 
-func requestFrom(ctx map[string]interface{}) request {
+func requestFrom(ctx map[string]any) request {
 	return request{
 		Context: ctx,
 	}
 }
 
 type evaluationSuccess struct {
-	Value    interface{} `json:"value"`
-	Key      string      `json:"key"`
-	Reason   string      `json:"reason"`
-	Variant  string      `json:"variant"`
-	Metadata interface{} `json:"metadata"`
+	Value    any    `json:"value"`
+	Key      string `json:"key"`
+	Reason   string `json:"reason"`
+	Variant  string `json:"variant"`
+	Metadata any    `json:"metadata"`
 }
 
 type evaluationError struct {

--- a/internal/evaluate/resolver_test.go
+++ b/internal/evaluate/resolver_test.go
@@ -22,7 +22,7 @@ var success = evaluationSuccess{
 	Key:     "flagA",
 	Reason:  string(of.StaticReason),
 	Variant: "true",
-	Metadata: map[string]interface{}{
+	Metadata: map[string]any{
 		"key": "value",
 	},
 }
@@ -56,7 +56,7 @@ func TestSuccess200(t *testing.T) {
 			},
 		}}
 
-		successDto, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]interface{}))
+		successDto, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]any))
 
 		if resolutionError != nil {
 			t.Errorf("expected no errors, but got error: %v", err)
@@ -90,7 +90,7 @@ func TestSuccess200(t *testing.T) {
 				Data:   []byte("some payload"),
 			},
 		}}
-		success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]interface{}))
+		success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]any))
 
 		validateErrorCode(t, success, resolutionError, of.ParseErrorCode)
 	})
@@ -107,7 +107,7 @@ func TestSuccess200(t *testing.T) {
 				Data:   b,
 			},
 		}}
-		success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]interface{}))
+		success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]any))
 
 		validateErrorCode(t, success, resolutionError, of.ParseErrorCode)
 	})
@@ -123,7 +123,7 @@ func TestSuccess200(t *testing.T) {
 				Data:   b,
 			},
 		}}
-		success, _ := resolver.resolveSingle(context.Background(), "", make(map[string]interface{}))
+		success, _ := resolver.resolveSingle(context.Background(), "", make(map[string]any))
 
 		if len(success.Metadata) > 0 {
 			t.Errorf("should not have metadata, but got %v", success.Metadata)
@@ -169,7 +169,7 @@ func TestResolveGeneralErrors(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			resolver := OutboundResolver{client: test.client}
-			success, resolutionError := resolver.resolveSingle(context.Background(), "key", map[string]interface{}{})
+			success, resolutionError := resolver.resolveSingle(context.Background(), "key", map[string]any{})
 
 			validateErrorCode(t, success, resolutionError, of.GeneralCode)
 		})
@@ -225,7 +225,7 @@ func TestEvaluationError4xx(t *testing.T) {
 					Data:   errBytes,
 				},
 			}}
-			success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]interface{}))
+			success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]any))
 
 			validateErrorCode(t, success, resolutionError, test.expectCode)
 		})
@@ -238,7 +238,7 @@ func TestFlagNotFound404(t *testing.T) {
 			Status: http.StatusNotFound,
 		},
 	}}
-	success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]interface{}))
+	success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]any))
 
 	validateErrorCode(t, success, resolutionError, of.FlagNotFoundCode)
 }
@@ -275,7 +275,7 @@ func Test429(t *testing.T) {
 			}
 
 			resolver := OutboundResolver{client: mockOutbound{rsp: response}}
-			success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]interface{}))
+			success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]any))
 
 			validateErrorCode(t, success, resolutionError, of.GeneralCode)
 		})
@@ -290,7 +290,7 @@ func TestEvaluationError5xx(t *testing.T) {
 				Data:   []byte{},
 			},
 		}}
-		success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]interface{}))
+		success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]any))
 
 		validateErrorCode(t, success, resolutionError, of.GeneralCode)
 	})
@@ -307,7 +307,7 @@ func TestEvaluationError5xx(t *testing.T) {
 				Data:   errorBytes,
 			},
 		}}
-		success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]interface{}))
+		success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]any))
 
 		validateErrorCode(t, success, resolutionError, of.GeneralCode)
 	})
@@ -319,7 +319,7 @@ func TestEvaluationError5xx(t *testing.T) {
 				Data:   []byte("some error"),
 			},
 		}}
-		success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]interface{}))
+		success, resolutionError := resolver.resolveSingle(context.Background(), "", make(map[string]any))
 
 		validateErrorCode(t, success, resolutionError, of.GeneralCode)
 	})

--- a/internal/outbound/http.go
+++ b/internal/outbound/http.go
@@ -22,6 +22,7 @@ type Configuration struct {
 	Callbacks             []HeaderCallback
 	Client                *http.Client
 	ClientPollingInterval time.Duration
+	Timeout               time.Duration
 }
 
 func (c *Configuration) PollingEnabled() bool {
@@ -47,8 +48,12 @@ type Outbound struct {
 
 func NewHTTP(cfg Configuration) *Outbound {
 	if cfg.Client == nil {
+		timeout := cfg.Timeout
+		if timeout <= 0 {
+			timeout = 10 * time.Second
+		}
 		cfg.Client = &http.Client{
-			Timeout: 10 * time.Second,
+			Timeout: timeout,
 		}
 	}
 

--- a/provider.go
+++ b/provider.go
@@ -3,6 +3,11 @@ package ofrep
 import (
 	"context"
 	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/open-feature/go-sdk-contrib/providers/ofrep/internal/evaluate"
 	"github.com/open-feature/go-sdk-contrib/providers/ofrep/internal/outbound"
@@ -21,8 +26,15 @@ type Option func(*outbound.Configuration)
 func NewProvider(baseURI string, options ...Option) *Provider {
 	cfg := outbound.Configuration{
 		BaseURI: baseURI,
+		Timeout: 10 * time.Second,
 	}
 
+	// Apply configuration from OFREP environment variables
+	WithFromEnv()(&cfg)
+	// Follow the spec - allow programmatic configuration to override environment variables
+	if baseURI != "" {
+		cfg.BaseURI = baseURI
+	}
 	for _, option := range options {
 		option(&cfg)
 	}
@@ -56,7 +68,7 @@ func (p Provider) IntEvaluation(ctx context.Context, flag string, defaultValue i
 	return p.evaluator.ResolveInt(ctx, flag, defaultValue, evalCtx)
 }
 
-func (p Provider) ObjectEvaluation(ctx context.Context, flag string, defaultValue interface{}, evalCtx openfeature.FlattenedContext) openfeature.InterfaceResolutionDetail {
+func (p Provider) ObjectEvaluation(ctx context.Context, flag string, defaultValue any, evalCtx openfeature.FlattenedContext) openfeature.InterfaceResolutionDetail {
 	return p.evaluator.ResolveObject(ctx, flag, defaultValue, evalCtx)
 }
 
@@ -96,5 +108,87 @@ func WithApiKeyAuth(token string) func(*outbound.Configuration) {
 func WithClient(client *http.Client) func(configuration *outbound.Configuration) {
 	return func(configuration *outbound.Configuration) {
 		configuration.Client = client
+	}
+}
+
+// WithHeader allows to set a custom header.
+func WithHeader(key, value string) func(*outbound.Configuration) {
+	return func(c *outbound.Configuration) {
+		c.Callbacks = append(c.Callbacks, func() (string, string) {
+			return key, value
+		})
+	}
+}
+
+// WithBaseURI allows to override the base URI of the OFREP service.
+func WithBaseURI(baseURI string) func(*outbound.Configuration) {
+	return func(c *outbound.Configuration) {
+		c.BaseURI = baseURI
+	}
+}
+
+// WithTimeout allows to configure the timeout for the http client used for communication with the OFREP service.
+// This option is ignored if a custom client is provided via WithClient.
+func WithTimeout(timeout time.Duration) func(*outbound.Configuration) {
+	return func(c *outbound.Configuration) {
+		c.Timeout = timeout
+	}
+}
+
+// WithFromEnv configures the provider using environment variables.
+//
+// Supported environment variables:
+//
+//   - OFREP_ENDPOINT: Base URL of the OFREP service.
+//   - OFREP_TIMEOUT_MS: Request timeout in milliseconds (e.g., "5000").
+//   - OFREP_HEADERS: Comma-separated list of custom headers
+//     (e.g., "Key1=Value1,Key2=Value2").
+//
+// When provided, environment variables take precedence over values
+// set programmatically via previous options.
+//
+// Example:
+//
+//	provider := NewProvider(
+//	    "https://ofrep.localhost/",
+//	    WithTimeout(time.Minute),
+//	    WithFromEnv(),
+//	)
+//
+// In this example, if OFREP_ENDPOINT or OFREP_TIMEOUT_MS are set,
+// their values override the ones passed via programmatic options.
+func WithFromEnv() func(*outbound.Configuration) {
+	envHandlers := map[string]func(*outbound.Configuration, string){
+		"OFREP_ENDPOINT": func(c *outbound.Configuration, v string) {
+			WithBaseURI(v)(c)
+		},
+		"OFREP_TIMEOUT_MS": func(c *outbound.Configuration, v string) {
+			t, err := strconv.Atoi(v)
+			if err == nil && t > 0 {
+				WithTimeout(time.Duration(t) * time.Millisecond)(c)
+			}
+		},
+		"OFREP_HEADERS": func(c *outbound.Configuration, v string) {
+			v, err := url.PathUnescape(v)
+			if err != nil {
+				return
+			}
+			for pair := range strings.SplitSeq(v, ",") {
+				kv := strings.SplitN(pair, "=", 2)
+				if len(kv) != 2 {
+					continue
+				}
+				k := strings.TrimSpace(kv[0])
+				v := strings.TrimSpace(kv[1])
+				WithHeader(k, v)(c)
+			}
+		},
+	}
+	return func(c *outbound.Configuration) {
+		for key, handler := range envHandlers {
+			if v := os.Getenv(key); v != "" {
+				handler(c, v)
+			}
+		}
 	}
 }

--- a/provider_test.go
+++ b/provider_test.go
@@ -65,14 +65,7 @@ func TestConfigurations(t *testing.T) {
 }
 
 func TestWiringE2E(t *testing.T) {
-	// mock server with mocked response
-	server := httptest.NewServer(
-		mockHandler{
-			response: "{\"value\":true,\"key\":\"my-flag\",\"reason\":\"STATIC\",\"variant\":\"true\",\"metadata\":{}}",
-			t:        t,
-		},
-	)
-	t.Cleanup(server.Close)
+	server := newMockServer(t, `{"value":true,"key":"my-flag","reason":"STATIC","variant":"true","metadata":{}}`)
 
 	// custom client with reduced timeout
 	customClient := &http.Client{
@@ -108,6 +101,252 @@ func (r mockHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	resp.WriteHeader(http.StatusOK)
 	_, err := resp.Write([]byte(r.response))
 	if err != nil {
-		r.t.Logf("error wriging bytes: %v", err)
+		r.t.Logf("error writing bytes: %v", err)
+	}
+}
+
+func newMockServer(t *testing.T, response string) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(mockHandler{response: response, t: t})
+	t.Cleanup(s.Close)
+	return s
+}
+
+func TestStringEvaluation(t *testing.T) {
+	server := newMockServer(t, `{"value":"hello","key":"my-flag","reason":"STATIC","variant":"variant","metadata":{}}`)
+	provider := NewProvider(server.URL, WithClient(&http.Client{Timeout: 1 * time.Second}))
+	result := provider.StringEvaluation(context.Background(), "flag", "default", nil)
+
+	if result.Value != "hello" {
+		t.Errorf("expected %q, got %q", "hello", result.Value)
+	}
+	if result.Variant != "variant" {
+		t.Errorf("expected %q, got %q", "variant", result.Variant)
+	}
+	if result.Reason != openfeature.StaticReason {
+		t.Errorf("expected %v, got %v", openfeature.StaticReason, result.Reason)
+	}
+	if result.Error() != nil {
+		t.Errorf("expected no error, got %v", result.Error())
+	}
+}
+
+func TestFloatEvaluation(t *testing.T) {
+	server := newMockServer(t, `{"value":3.14,"key":"my-flag","reason":"STATIC","variant":"variant","metadata":{}}`)
+	provider := NewProvider(server.URL, WithClient(&http.Client{Timeout: 1 * time.Second}))
+	result := provider.FloatEvaluation(context.Background(), "flag", 0.0, nil)
+
+	if result.Value != 3.14 {
+		t.Errorf("expected %v, got %v", 3.14, result.Value)
+	}
+	if result.Variant != "variant" {
+		t.Errorf("expected %q, got %q", "variant", result.Variant)
+	}
+	if result.Reason != openfeature.StaticReason {
+		t.Errorf("expected %v, got %v", openfeature.StaticReason, result.Reason)
+	}
+	if result.Error() != nil {
+		t.Errorf("expected no error, got %v", result.Error())
+	}
+}
+
+func TestIntEvaluation(t *testing.T) {
+	server := newMockServer(t, `{"value":42,"key":"my-flag","reason":"STATIC","variant":"variant","metadata":{}}`)
+	provider := NewProvider(server.URL, WithClient(&http.Client{Timeout: 1 * time.Second}))
+	result := provider.IntEvaluation(context.Background(), "flag", 0, nil)
+
+	if result.Value != 42 {
+		t.Errorf("expected %v, got %v", 42, result.Value)
+	}
+	if result.Variant != "variant" {
+		t.Errorf("expected %q, got %q", "variant", result.Variant)
+	}
+	if result.Reason != openfeature.StaticReason {
+		t.Errorf("expected %v, got %v", openfeature.StaticReason, result.Reason)
+	}
+	if result.Error() != nil {
+		t.Errorf("expected no error, got %v", result.Error())
+	}
+}
+
+func TestObjectEvaluation(t *testing.T) {
+	server := newMockServer(t, `{"value":{"key":"val"},"key":"my-flag","reason":"STATIC","variant":"variant","metadata":{}}`)
+	provider := NewProvider(server.URL, WithClient(&http.Client{Timeout: 1 * time.Second}))
+	result := provider.ObjectEvaluation(context.Background(), "flag", nil, nil)
+
+	if result.Error() != nil {
+		t.Errorf("expected no error, got %v", result.Error())
+	}
+	if result.Variant != "variant" {
+		t.Errorf("expected %q, got %q", "variant", result.Variant)
+	}
+	if result.Reason != openfeature.StaticReason {
+		t.Errorf("expected %v, got %v", openfeature.StaticReason, result.Reason)
+	}
+
+	m, ok := result.Value.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", result.Value)
+	}
+	if m["key"] != "val" {
+		t.Errorf("expected %q, got %v", "val", m["key"])
+	}
+}
+
+func TestWithFromEnv(t *testing.T) {
+	tests := []struct {
+		name          string
+		envVars       map[string]string
+		initialConfig outbound.Configuration
+		baseURI       string
+		wantBaseURI   string
+		wantTimeout   time.Duration
+		wantHeaders   map[string]string
+	}{
+		{
+			name: "configure endpoint from env",
+			envVars: map[string]string{
+				"OFREP_ENDPOINT": "http://test.example.com",
+			},
+			initialConfig: outbound.Configuration{},
+			wantBaseURI:   "http://test.example.com",
+		},
+		{
+			name: "configure timeout from env with raw milliseconds",
+			envVars: map[string]string{
+				"OFREP_TIMEOUT_MS": "3000",
+			},
+			initialConfig: outbound.Configuration{},
+			wantTimeout:   3 * time.Second,
+		},
+		{
+			name: "configure timeout from env with negative milliseconds",
+			envVars: map[string]string{
+				"OFREP_TIMEOUT_MS": "-5000",
+			},
+			initialConfig: outbound.Configuration{Timeout: 33 * time.Second},
+			wantTimeout:   33 * time.Second,
+		},
+		{
+			name: "ignore invalid timeout",
+			envVars: map[string]string{
+				"OFREP_TIMEOUT_MS": "invalid",
+			},
+			initialConfig: outbound.Configuration{Timeout: 10 * time.Second},
+			wantTimeout:   10 * time.Second,
+		},
+		{
+			name: "configure custom headers from env",
+			envVars: map[string]string{
+				"OFREP_HEADERS": "X-Custom-1=Value1,X-Custom-2=Value2",
+			},
+			initialConfig: outbound.Configuration{},
+			wantHeaders: map[string]string{
+				"X-Custom-1": "Value1",
+				"X-Custom-2": "Value2",
+			},
+		},
+		{
+			name: "configure all options from env",
+			envVars: map[string]string{
+				"OFREP_ENDPOINT":   "http://all.example.com",
+				"OFREP_TIMEOUT_MS": "3000",
+				"OFREP_HEADERS":    "X-Test=TestValue",
+			},
+			initialConfig: outbound.Configuration{},
+			wantBaseURI:   "http://all.example.com",
+			wantTimeout:   3 * time.Second,
+			wantHeaders: map[string]string{
+				"X-Test": "TestValue",
+			},
+		},
+		{
+			name: "empty env variables do not override defaults",
+			envVars: map[string]string{
+				"OFREP_ENDPOINT":   "",
+				"OFREP_TIMEOUT_MS": "",
+			},
+			initialConfig: outbound.Configuration{
+				BaseURI: "http://default.example.com",
+				Timeout: 15 * time.Second,
+			},
+			wantBaseURI: "http://default.example.com",
+			wantTimeout: 15 * time.Second,
+		},
+		{
+			name: "configure headers with baggage header format",
+			envVars: map[string]string{
+				"OFREP_HEADERS": "Key1=value1 ,Key2=val%3Due2,Key3=base64==,Key4 = 50%25",
+			},
+			initialConfig: outbound.Configuration{},
+			wantHeaders: map[string]string{
+				"Key1": "value1",
+				"Key2": "val=ue2",
+				"Key3": "base64==",
+				"Key4": "50%",
+			},
+		},
+		{
+			name: "configure headers with auth header format",
+			envVars: map[string]string{
+				"OFREP_HEADERS": "Authorization=Bearer%20token,X-Custom=value",
+			},
+			initialConfig: outbound.Configuration{},
+			wantHeaders: map[string]string{
+				"Authorization": "Bearer token",
+				"X-Custom":      "value",
+			},
+		},
+		{
+			name: "programmatic baseURI overrides env",
+			envVars: map[string]string{
+				"OFREP_ENDPOINT": "http://env.example.com",
+			},
+			initialConfig: outbound.Configuration{},
+			baseURI:       "http://programmatic.example.com",
+			wantBaseURI:   "http://programmatic.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for key, value := range tt.envVars {
+				t.Setenv(key, value)
+			}
+
+			c := tt.initialConfig
+			WithFromEnv()(&c)
+			if tt.baseURI != "" {
+				c.BaseURI = tt.baseURI
+			}
+
+			if tt.wantBaseURI != "" && c.BaseURI != tt.wantBaseURI {
+				t.Errorf("expected BaseURI %s, but got %s", tt.wantBaseURI, c.BaseURI)
+			}
+
+			if tt.wantTimeout != 0 && c.Timeout != tt.wantTimeout {
+				t.Errorf("expected Timeout %v, but got %v", tt.wantTimeout, c.Timeout)
+			}
+
+			actualHeaders := make(map[string]string)
+			for _, cb := range c.Callbacks {
+				k, v := cb()
+				actualHeaders[k] = v
+			}
+
+			if tt.wantHeaders != nil {
+				for expectedKey, expectedValue := range tt.wantHeaders {
+					if actualValue, ok := actualHeaders[expectedKey]; !ok {
+						t.Errorf("expected header %s not found", expectedKey)
+					} else if actualValue != expectedValue {
+						t.Errorf("expected %s=%s, but got %s=%s", expectedKey, expectedValue, expectedKey, actualValue)
+					}
+				}
+			}
+
+			if len(tt.wantHeaders) == 0 && len(actualHeaders) != 0 {
+				t.Errorf("expected no headers, but got %v", actualHeaders)
+			}
+		})
 	}
 }


### PR DESCRIPTION
- Cherry-pick WithFromEnv() from upstream PR #786 for env-based config
  (OFREP_ENDPOINT, OFREP_TIMEOUT_MS, OFREP_HEADERS)
- Add Timeout field to outbound.Configuration and wire it into http client
- Add mise test task and coverage.txt to .gitignore
- Replace interface{} with any across all packages
- Add tests for StringEvaluation, FloatEvaluation, IntEvaluation, ObjectEvaluation
- Extract newMockServer test helper, fix typo in mockHandler
